### PR TITLE
Add postgres_query task

### DIFF
--- a/prefect_postgres/__init__.py
+++ b/prefect_postgres/__init__.py
@@ -1,3 +1,4 @@
 from . import _version
+from prefect_postgres.credentials import PostgresCredentials  # noqa
 
 __version__ = _version.get_versions()["version"]

--- a/prefect_postgres/_version.py
+++ b/prefect_postgres/_version.py
@@ -43,7 +43,7 @@ def get_config():
     cfg.style = "pep440"
     cfg.tag_prefix = ""
     cfg.parentdir_prefix = ""
-    cfg.versionfile_source = "prefect_snowflake/_version.py"
+    cfg.versionfile_source = "prefect_postgres/_version.py"
     cfg.verbose = False
     return cfg
 

--- a/prefect_postgres/_version.py
+++ b/prefect_postgres/_version.py
@@ -43,7 +43,7 @@ def get_config():
     cfg.style = "pep440"
     cfg.tag_prefix = ""
     cfg.parentdir_prefix = ""
-    cfg.versionfile_source = "prefect_postgres/_version.py"
+    cfg.versionfile_source = "prefect_snowflake/_version.py"
     cfg.verbose = False
     return cfg
 

--- a/prefect_postgres/credentials.py
+++ b/prefect_postgres/credentials.py
@@ -1,1 +1,73 @@
-"""Credential classes used to perform authenticated interactions with prefect_postgres"""
+"""Credentials class to authenticate Postgres."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+import psycopg2
+
+
+@dataclass
+class PostgresCredentials:
+    """
+    Dataclass used to manage authentication with Postgres.
+
+    Args:
+        user: The user name used to authenticate.
+        password: The password used to authenticate.
+        database: The name of the Postgres database.
+        host: The host address of the database.
+        port: The port to connect to the database.
+    """  # noqa
+
+    user: str
+    password: str
+    database: Optional[str] = None
+    host: Optional[str] = "localhost"
+    port: Optional[int] = 5432
+
+    def get_connection(
+        self, database: Optional[str] = None
+    ) -> psycopg2.extensions.connection:
+        """
+        Returns an authenticated connection that can be
+        used to query from Postgres databases.
+
+        Args:
+            database: The name of the database to use; overrides
+                the class definition if provided.
+    
+        Returns:
+            The authenticated Postgres connection.
+
+        Examples:
+            ```python
+            from prefect import flow
+            from prefect_postgres import PostgresCredentials
+
+            @flow
+            def postgres_credentials_flow():
+                postgres_credentials = PostgresCredentials(
+                    user="user",
+                    password="password",
+                    database="postgres",
+                    host="127.0.0.1"
+                )
+                return postgres_credentials
+
+            postgres_credentials_flow()
+            ```
+        """
+        database = self.database or database
+        if database is None:
+            raise ValueError(
+                f"The database must be set in either "
+                f"PostgresCredentials or the task"
+            )
+
+        return psycopg2.connect(
+            database=database,
+            user=self.user,
+            password=self.password,
+            host=self.host,
+            port=self.port,
+        )

--- a/prefect_postgres/credentials.py
+++ b/prefect_postgres/credentials.py
@@ -35,7 +35,7 @@ class PostgresCredentials:
         Args:
             database: The name of the database to use; overrides
                 the class definition if provided.
-    
+
         Returns:
             The authenticated Postgres connection.
 
@@ -60,8 +60,7 @@ class PostgresCredentials:
         database = self.database or database
         if database is None:
             raise ValueError(
-                f"The database must be set in either "
-                f"PostgresCredentials or the task"
+                "The database must be set in either " "PostgresCredentials or the task"
             )
 
         return psycopg2.connect(

--- a/prefect_postgres/database.py
+++ b/prefect_postgres/database.py
@@ -1,0 +1,71 @@
+"""Module for querying against Snowflake database."""
+
+from functools import partial
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from anyio import to_thread
+from prefect import task
+
+from prefect_postgres.credentials import PostgresCredentials
+
+
+@task
+async def postgres_query(
+    query: str,
+    postgres_credentials: PostgresCredentials,
+    params: Union[Tuple[Any], Dict[str, Any]] = None,
+    database: Optional[str] = None,
+) -> List[Tuple[Any]]:
+    """
+    Executes a query against a Snowflake database.
+
+    Args:
+        query: The query to execute against the database.
+        params: The params to replace the placeholders in the query.
+        postgres_credentials: The credentials to use to authenticate.
+        database: The name of the database to use; overrides
+            the credentials definition if provided.
+
+    Returns:
+        The output of `response.fetchall()`.
+
+    Examples:
+        Query Snowflake table with the ID value parameterized.
+        ```python
+        from prefect import flow
+        from prefect_postgres import PostgresCredentials
+        from prefect_postgres.database import postgres_query
+
+
+        @flow
+        def postgres_query_flow():
+            postgres_credentials = PostgresCredentials(
+                user="user",
+                password="password",
+                database="postgres",
+            )
+            result = postgres_query(
+                "SELECT * FROM table WHERE id=%{id_param}s LIMIT 8;",
+                postgres_credentials,
+                params={"id_param": 1}
+            )
+            return result
+
+        postgres_query_flow()
+        ```
+    """
+    connection = postgres_credentials.get_connection(database=database)
+    try:
+        with connection, connection.cursor() as cursor:
+            partial_execute = partial(cursor.execute, query, params)
+            await to_thread.run_sync(partial_execute)
+            partial_fetchall = partial(cursor.fetchall)
+            result = await to_thread.run_sync(partial_fetchall)
+    finally:
+        # Unlike file objects or other resources, exiting the
+        # connection’s with block doesn’t close the connection,
+        # https://www.psycopg.org/docs/usage.html#with-statement
+        # cursor does indeed get closed though
+        connection.close()
+
+    return result

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,3 +1,31 @@
+import pytest
 from unittest.mock import MagicMock
 
 from prefect import flow
+
+from prefect_postgres.credentials import PostgresCredentials
+
+
+def test_postgres_credentials_get_connection_override(monkeypatch):
+    connect_mock = MagicMock()
+    monkeypatch.setattr("psycopg2.connect", connect_mock)
+
+    connection = PostgresCredentials(
+        "user",
+        "password",
+        database="database"
+    ).get_connection(
+        database="override_database"
+    )
+    connect_mock.assert_called_with(
+        database='database',
+        user='user',
+        password='password',
+        host='localhost',
+        port=5432
+    )
+
+
+def test_postgres_credentials_get_connection_missing_database():
+    with pytest.raises(ValueError, match=f"The database must be set in either"):
+        PostgresCredentials("user", "password").get_connection()

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,7 +1,6 @@
-import pytest
 from unittest.mock import MagicMock
 
-from prefect import flow
+import pytest
 
 from prefect_postgres.credentials import PostgresCredentials
 
@@ -10,22 +9,18 @@ def test_postgres_credentials_get_connection_override(monkeypatch):
     connect_mock = MagicMock()
     monkeypatch.setattr("psycopg2.connect", connect_mock)
 
-    connection = PostgresCredentials(
-        "user",
-        "password",
-        database="database"
-    ).get_connection(
+    PostgresCredentials("user", "password", database="database").get_connection(
         database="override_database"
     )
     connect_mock.assert_called_with(
-        database='database',
-        user='user',
-        password='password',
-        host='localhost',
-        port=5432
+        database="database",
+        user="user",
+        password="password",
+        host="localhost",
+        port=5432,
     )
 
 
 def test_postgres_credentials_get_connection_missing_database():
-    with pytest.raises(ValueError, match=f"The database must be set in either"):
+    with pytest.raises(ValueError, match="The database must be set in either"):
         PostgresCredentials("user", "password").get_connection()


### PR DESCRIPTION
Curious if we should follow how the tasks are set up in v1 or just fetchall, or have a keyword with `fetch=None` which fetchall or `fetch=10` which gets 10.

https://docs.prefect.io/api/latest/tasks/postgres.html#postgresexecute

Also wondering how the async should work; https://www.psycopg.org/docs/advanced.html#asynchronous-support looks hacky.